### PR TITLE
Major export improvements

### DIFF
--- a/unity-gltf-exporter/Assets/PlattarExporter/Plattar/Editor/Exporter.cs
+++ b/unity-gltf-exporter/Assets/PlattarExporter/Plattar/Editor/Exporter.cs
@@ -238,14 +238,15 @@ namespace Plattar {
 				DirectoryInfo info = Directory.CreateDirectory(newpath);
 
 				if (info.Exists) {
-					if (PlattarExporterOptions.ExportAnimations == true) {
+					//if (PlattarExporterOptions.ExportAnimations == true) {
 						var exporter = new GLTFEditorExporter(new Transform[] { selectedObject.transform });
+						exporter.enableAnimation(PlattarExporterOptions.ExportAnimations == true);
 						exporter.SaveGLTFandBin(newpath, selectionName);
-					} 
-					else {
-						var exporter = new GLTFSceneExporter(new Transform[] { selectedObject.transform });
-						exporter.SaveGLTFandBin(newpath, selectionName);
-					}
+					//} 
+					//else {
+					//	var exporter = new GLTFSceneExporter(new Transform[] { selectedObject.transform });
+					//	exporter.SaveGLTFandBin(newpath, selectionName);
+					//}
 
 					return new Tuple<string, string, string>(path, newpath, selectedName);
 				}

--- a/unity-gltf-exporter/Assets/PlattarExporter/Plattar/Editor/Exporter.cs
+++ b/unity-gltf-exporter/Assets/PlattarExporter/Plattar/Editor/Exporter.cs
@@ -103,6 +103,7 @@ namespace Plattar {
 					return;
 				}
 
+				/* Don't forbid exporting objects without geometry (e.g. skeletons)
 				var meshes = selectedObject.GetComponentsInChildren<MeshFilter>();
 				var skinnedMeshes = selectedObject.GetComponentsInChildren<SkinnedMeshRenderer>();
 
@@ -113,6 +114,7 @@ namespace Plattar {
 
 					return;
 				}
+				*/
 
 				EditorGUILayout.Separator();
 

--- a/unity-gltf-exporter/Assets/PlattarExporter/UnityGLTF/Scripts/GLTFEditorExporter.cs
+++ b/unity-gltf-exporter/Assets/PlattarExporter/UnityGLTF/Scripts/GLTFEditorExporter.cs
@@ -166,7 +166,6 @@ namespace UnityGLTF
 				Id = _root.Buffers.Count,
 				Root = _root
 			};
-			_root.Buffers.Add(_buffer);
 		}
 
 		/// <summary>
@@ -218,10 +217,24 @@ namespace UnityGLTF
 				exportAnimation(skinnedBones);
 			}
 
-			_buffer.Uri = fileName + ".bin";
-			_buffer.ByteLength = (int)_bufferWriter.BaseStream.Length;
+			int binSize = (int)_bufferWriter.BaseStream.Length;
+#if WINDOWS_UWP
+			binFile.Dispose();
+#else
+			binFile.Close();
+#endif
 
-			_exportedFiles.Add(binPath, "");
+			if (binSize > 0)
+			{
+				_buffer.Uri = fileName + ".bin";
+				_buffer.ByteLength = binSize;
+				_root.Buffers.Add(_buffer);
+				_exportedFiles.Add(binPath, "");
+			}
+			else
+			{
+				File.Delete(binPath);
+			}
 
 			string gltfPath = Path.Combine(path, fileName + ".gltf");
 			var gltfFile = File.CreateText(gltfPath);
@@ -229,10 +242,8 @@ namespace UnityGLTF
 
 #if WINDOWS_UWP
 			gltfFile.Dispose();
-			binFile.Dispose();
 #else
 			gltfFile.Close();
-			binFile.Close();
 #endif
 			_exportedFiles.Add(gltfPath, "");
 			bool backup = GL.sRGBWrite;

--- a/unity-gltf-exporter/Assets/PlattarExporter/UnityGLTF/Scripts/GLTFEditorExporter.cs
+++ b/unity-gltf-exporter/Assets/PlattarExporter/UnityGLTF/Scripts/GLTFEditorExporter.cs
@@ -1355,41 +1355,29 @@ namespace UnityGLTF
 			accessor.Count = count;
 			accessor.Type = GLTFAccessorAttributeType.VEC3;
 
-			float minX = arr[0].x;
-			float minY = arr[0].y;
-			float minZ = arr[0].z;
-			float maxX = arr[0].x;
-			float maxY = arr[0].y;
-			float maxZ = arr[0].z;
+			Vector3 first = switchHandedness ? arr[0].switchHandedness() : arr[0];
+			float minX = first.x;
+			float minY = first.y;
+			float minZ = first.z;
+			float maxX = first.x;
+			float maxY = first.y;
+			float maxZ = first.z;
 
 			for (var i = 1; i < count; i++)
 			{
-				var cur = arr[i];
-
+				Vector3 cur = switchHandedness ? arr[i].switchHandedness() : arr[i];
 				if (cur.x < minX)
-				{
 					minX = cur.x;
-				}
-				if (cur.y < minY)
-				{
-					minY = cur.y;
-				}
-				if (cur.z < minZ)
-				{
-					minZ = cur.z;
-				}
-				if (cur.x > maxX)
-				{
+				else if (cur.x > maxX)
 					maxX = cur.x;
-				}
-				if (cur.y > maxY)
-				{
+				if (cur.y < minY)
+					minY = cur.y;
+				else if (cur.y > maxY)
 					maxY = cur.y;
-				}
-				if (cur.z > maxZ)
-				{
+				if (cur.z < minZ)
+					minZ = cur.z;
+				else if (cur.z > maxZ)
 					maxZ = cur.z;
-				}
 			}
 
 			accessor.Min = new List<double> { minX, minY, minZ };
@@ -1397,20 +1385,12 @@ namespace UnityGLTF
 
 			var byteOffset = _bufferWriter.BaseStream.Position;
 
-			foreach (var vec in arr) {
-				if(switchHandedness)
-				{
-					Vector3 vect = vec.switchHandedness();
-					_bufferWriter.Write(vect.x);
-					_bufferWriter.Write(vect.y);
-					_bufferWriter.Write(vect.z);
-				}
-				else
-				{
-					_bufferWriter.Write(vec.x);
-					_bufferWriter.Write(vec.y);
-					_bufferWriter.Write(vec.z);
-				}
+			foreach (var vec in arr)
+			{
+				Vector3 vect = switchHandedness ? vec.switchHandedness() : vec;
+				_bufferWriter.Write(vect.x);
+				_bufferWriter.Write(vect.y);
+				_bufferWriter.Write(vect.z);
 			}
 
 			var byteLength = _bufferWriter.BaseStream.Position - byteOffset;
@@ -1441,41 +1421,29 @@ namespace UnityGLTF
 			accessor.Type = GLTFAccessorAttributeType.VEC3;
 
 			if (GLTFUtils.boundsExportOption == GLTFUtils.BoundsExportOption.Default) {
-				float minX = arr[0].x;
-				float minY = arr[0].y;
-				float minZ = arr[0].z;
-				float maxX = arr[0].x;
-				float maxY = arr[0].y;
-				float maxZ = arr[0].z;
+				Vector3 first = switchHandedness ? arr[0].switchHandedness() : arr[0];
+				float minX = first.x;
+				float minY = first.y;
+				float minZ = first.z;
+				float maxX = first.x;
+				float maxY = first.y;
+				float maxZ = first.z;
 
 				for (var i = 1; i < count; i++)
 				{
-					var cur = arr[i];
-
+					Vector3 cur = switchHandedness ? arr[i].switchHandedness() : arr[i];
 					if (cur.x < minX)
-					{
 						minX = cur.x;
-					}
-					if (cur.y < minY)
-					{
-						minY = cur.y;
-					}
-					if (cur.z < minZ)
-					{
-						minZ = cur.z;
-					}
-					if (cur.x > maxX)
-					{
+					else if (cur.x > maxX)
 						maxX = cur.x;
-					}
-					if (cur.y > maxY)
-					{
+					if (cur.y < minY)
+						minY = cur.y;
+					else if (cur.y > maxY)
 						maxY = cur.y;
-					}
-					if (cur.z > maxZ)
-					{
+					if (cur.z < minZ)
+						minZ = cur.z;
+					else if (cur.z > maxZ)
 						maxZ = cur.z;
-					}
 				}
 
 				accessor.Min = new List<double> { minX, minY, minZ };
@@ -1506,20 +1474,12 @@ namespace UnityGLTF
 
 			var byteOffset = _bufferWriter.BaseStream.Position;
 
-			foreach (var vec in arr) {
-				if(switchHandedness)
-				{
-					Vector3 vect = vec.switchHandedness();
-					_bufferWriter.Write(vect.x);
-					_bufferWriter.Write(vect.y);
-					_bufferWriter.Write(vect.z);
-				}
-				else
-				{
-					_bufferWriter.Write(vec.x);
-					_bufferWriter.Write(vec.y);
-					_bufferWriter.Write(vec.z);
-				}
+			foreach (var vec in arr)
+			{
+				Vector3 vect = switchHandedness ? vec.switchHandedness() : vec;
+				_bufferWriter.Write(vect.x);
+				_bufferWriter.Write(vect.y);
+				_bufferWriter.Write(vect.z);
 			}
 
 			var byteLength = _bufferWriter.BaseStream.Position - byteOffset;
@@ -1637,51 +1597,35 @@ namespace UnityGLTF
 			accessor.Count = count;
 			accessor.Type = GLTFAccessorAttributeType.VEC4;
 
-			float minX = arr[0].x;
-			float minY = arr[0].y;
-			float minZ = arr[0].z;
-			float minW = arr[0].w;
-			float maxX = arr[0].x;
-			float maxY = arr[0].y;
-			float maxZ = arr[0].z;
-			float maxW = arr[0].w;
+			Vector4 first = switchHandedness ? arr[0].switchHandedness() : arr[0];
+			float minX = first.x;
+			float minY = first.y;
+			float minZ = first.z;
+			float minW = first.w;
+			float maxX = first.x;
+			float maxY = first.y;
+			float maxZ = first.z;
+			float maxW = first.w;
 
 			for (var i = 1; i < count; i++)
 			{
-				var cur = arr[i];
-
+				Vector4 cur = switchHandedness ? arr[i].switchHandedness() : arr[i];
 				if (cur.x < minX)
-				{
 					minX = cur.x;
-				}
-				if (cur.y < minY)
-				{
-					minY = cur.y;
-				}
-				if (cur.z < minZ)
-				{
-					minZ = cur.z;
-				}
-				if (cur.w < minW)
-				{
-					minW = cur.w;
-				}
-				if (cur.x > maxX)
-				{
+				else if (cur.x > maxX)
 					maxX = cur.x;
-				}
-				if (cur.y > maxY)
-				{
+				if (cur.y < minY)
+					minY = cur.y;
+				else if (cur.y > maxY)
 					maxY = cur.y;
-				}
-				if (cur.z > maxZ)
-				{
+				if (cur.z < minZ)
+					minZ = cur.z;
+				else if (cur.z > maxZ)
 					maxZ = cur.z;
-				}
-				if (cur.w > maxW)
-				{
+				if (cur.w < minW)
+					minW = cur.w;
+				else if (cur.w > maxW)
 					maxW = cur.w;
-				}
 			}
 
 			accessor.Min = new List<double> { minX, minY, minZ, minW };
@@ -2007,7 +1951,7 @@ namespace UnityGLTF
 						_root.Animations.Add(anim);
 					}
 				}
-        	}
+			}
 		}
 
 		private int getTargetIdFromTransform(Transform transform)


### PR DESCRIPTION
### Export skin when SkinnedMeshRenderer.bones is empty
Sometimes SkinnedMeshRenderer has an empty array of bones. This is most likely due to an option "Optimize Game Object" on an [Import settings Rig tab](https://docs.unity3d.com/Manual/FBXImporter-Rig.html). This contribution restores skinning information from raw Unity asset data. I can't guarantee that it handles any possible situation but it proved useful in some real cases.

### Export skin without animations
Before these changes it was possible to only export both skin & animations or neither of them. Now you can disable animation export but still get skinned meshes exported.

### Humanoid animation export
Humanoid animations don't have SRT tracks but instead have special float tracks which control various conceptual properties of the human body. Instead of trying to repeat these calculations, an exporter now plays the final animation in the scene and samples SRT from affected nodes. This allows exporting humanoid animations as regular glTF animations easily.

### Export objects without geometry
Commented out a condition which blocked exporting a hierarchy without meshes. It is completely artificial limitation for both Unity and glTF.

### Fixes
Accessor bounds (min, max) are now correctly calculated in a case of switching vector handedness.

### Minor changes
Empty .bin file is not saved anymore.
Unnecessary fake animation tracks are not allocated.
